### PR TITLE
add override via lock file

### DIFF
--- a/xfce4-night-mode-redshift.sh
+++ b/xfce4-night-mode-redshift.sh
@@ -6,6 +6,23 @@
 
 # Change this variable to define which mode to use while RedShift transitions from day to night or vice versa
 # Choices: night|day
+
+# Print XML for genmon plugin
+set_mode() {
+  "$(dirname "$0")/xfce4-night-mode.sh" "$mode" | sed '/<tool>/,/<\/tool>/ d'
+  echo '<tool>
+    Night mode defined by RedShift
+    Click to toggle mode for a while
+  </tool>'
+  exit 0
+}
+
+# exit if override file exists to stay on current theme
+# for example if user changed it manually via UI and doesn't want it changed regardless of RedShift
+if [ -f /tmp/xfce4-night-mode.lock ]; then
+  set_mode
+fi
+
 TRANSITION_MODE='night'
 
 redshift_period=$( LC_ALL='C' redshift -p 2> /dev/null | grep -E '^Period: ' | grep -Eo '(Transition|Night|Day)' )
@@ -36,8 +53,4 @@ case $redshift_period in
     ;;
 esac
 
-"$(dirname "$0")/xfce4-night-mode.sh" "$mode" | sed '/<tool>/,/<\/tool>/ d'
-echo '<tool>
-  Night mode defined by RedShift
-  Click to toggle mode for a while
-</tool>'
+set_mode


### PR DESCRIPTION
Add manual override by creating a lock file - this will allow users to toggle the theme manually, create a file `/tmp/xfce4-night-mode.lock` and then not have the script change the theme until this file disappears (e.g. by rebooting and thereby clearing `/tmp`).